### PR TITLE
update Dockerfile de htseq ubuntu:12.04 --> ubuntu:14.04

### DIFF
--- a/htseq/htseq-0.6.1p1/Dockerfile
+++ b/htseq/htseq-0.6.1p1/Dockerfile
@@ -4,7 +4,7 @@
 ############################################################
 
 # Set the base image to Ubuntu
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 # File Author / Maintainer
 MAINTAINER Laurent Jourdren <jourdren@biologie.ens.fr>


### PR DESCRIPTION
Salut Laurent,

J'ai modifié le Dockerfile de la dernière version de htseq (htseq-0.6.1p1) en basant l'image sur ubuntu:14.04.

Bonne journée,
Alexandra
